### PR TITLE
Requirement: GraphQL endpoint to clean and initialize Ticket data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We've prepared a basic skeleton of a project to help you work a little bit faste
 
 ## Requirements
 
-- [ ] Provide a GraphQL endpoint to initiate cleaning and storing of ticket data into MonogDB from the provided external API
+- [x] Provide a GraphQL endpoint to initiate cleaning and storing of ticket data into MongoDB from the provided external API
   - API: `https://us-central1-bonsai-interview-endpoints.cloudfunctions.net/movieTickets?skip=0&limit=10`
   - The `skip` and `limit` parameters are the only ones that exist.
   - There are only `1000` movie tickets in this test feed but you should be able to consume more than that

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "apollo-server": "2.5.0",
+    "axios": "^0.19.0",
     "graphql": "14.3.0",
     "mongodb": "3.2.4",
     "mongoose": "5.5.7",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "mongoose": "5.5.7",
     "reflect-metadata": "0.1.13",
     "type-graphql": "0.17.3",
+    "rxjs": "^6.5.2",
     "typegoose": "5.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "mongodb": "3.2.4",
     "mongoose": "5.5.7",
     "reflect-metadata": "0.1.13",
-    "type-graphql": "0.17.3",
     "rxjs": "^6.5.2",
+    "type-graphql": "^0.17.5",
     "typegoose": "5.6.0"
   },
   "devDependencies": {

--- a/source/helpers/axiosResponseHandler.ts
+++ b/source/helpers/axiosResponseHandler.ts
@@ -1,0 +1,3 @@
+import { AxiosResponse } from "axios"
+
+export default (response: AxiosResponse<any>) => response.data

--- a/source/resolvers/AsyncIterableObserver.ts
+++ b/source/resolvers/AsyncIterableObserver.ts
@@ -1,0 +1,60 @@
+import { Observable } from "rxjs"
+
+/**
+ * Helper class to create an async iterable observer.
+ *
+ * This class subscribes to an Observable, and whenever the
+ * Observable publishes a value, it stores as a resolved value
+ * (so when the async iterator asks for the next value, it will
+ * be ready to serve), or resolves a pending value from the
+ * async iterator.
+ */
+class AsyncIterableObserver<T> implements AsyncIterable<T> {
+  observable: Observable<T>
+  isDone = false
+  resolvedValues: T[] = []
+  pendingResolves: { (data: T): void }[] = []
+
+  constructor(observable: Observable<T>) {
+    this.observable = observable
+  }
+
+  public subscribe(): void {
+    this.observable.subscribe(
+      next => {
+        const pendingResolve = this.pendingResolves.shift()
+        if (pendingResolve) {
+          pendingResolve(next)
+        } else {
+          this.resolvedValues.push(next)
+        }
+      },
+      error => {
+        const pendingResolve = this.pendingResolves.shift()
+        if (pendingResolve) {
+          pendingResolve(error)
+        } else {
+          this.resolvedValues.push(error)
+        }
+      },
+      () => {
+        this.isDone = true
+      },
+    )
+  }
+
+  [Symbol.asyncIterator]() {
+    return {
+      next: async (): Promise<IteratorResult<any>> => ({
+        done: this.isDone && this.resolvedValues.length === 0 && this.pendingResolves.length === 0,
+        value: this.resolvedValues.length
+          ? this.resolvedValues.shift()
+          : await new Promise(resolve => {
+              this.pendingResolves.push(resolve)
+            }),
+      }),
+    }
+  }
+}
+
+export default AsyncIterableObserver

--- a/source/resolvers/types/TicketSubscription.output.ts
+++ b/source/resolvers/types/TicketSubscription.output.ts
@@ -1,0 +1,9 @@
+import { Field, ObjectType } from "type-graphql"
+import { Ticket } from "../../entities/Ticket"
+
+@ObjectType()
+export class TicketSubscription {
+  @Field(() => [Ticket], { nullable: true })
+  public tickets?: Ticket[]
+}
+export default TicketSubscription

--- a/source/schema.gql
+++ b/source/schema.gql
@@ -34,6 +34,10 @@ type Query {
   listTickets(input: ListTicketsInput!): [Ticket!]!
 }
 
+type Subscription {
+  initializeTickets: TicketSubscription!
+}
+
 type Ticket {
   _id: ObjectId!
   title: String!
@@ -46,4 +50,8 @@ type Ticket {
 
 input TicketInput {
   id: ObjectId!
+}
+
+type TicketSubscription {
+  tickets: [Ticket!]
 }

--- a/source/services/BonsaiData.service.ts
+++ b/source/services/BonsaiData.service.ts
@@ -1,0 +1,68 @@
+import axios from "axios"
+import axiosResponseHandler from "../helpers/axiosResponseHandler"
+import RawTicket from "./model/RawTicket"
+import TicketModel from "../entities/Ticket"
+import transformGenres from "../helpers/transformGenres"
+import { BONSAI_MAX_TICKETS, BONSAI_TICKETS_BATCH_SIZE } from "../settings"
+
+const MOVIE_TICKETS_API_URL =
+  "https://us-central1-bonsai-interview-endpoints.cloudfunctions.net/movieTickets"
+
+/**
+ * Service responsible for fetching data from external source (Bonsai),
+ * handling any type of conversions to Ticket entity and persisting into the database.
+ */
+class BonsaiDataService {
+  /**
+   * Fetches tickets data in batches and returns promises, where each
+   * promise will be resolved into an array of tickets data.
+   *
+   * Amount of tickets retrieved and batch size are configurable via application
+   * settings.
+   */
+  public fetchTickets(
+    tickets: number = BONSAI_MAX_TICKETS,
+    batchSize: number = BONSAI_TICKETS_BATCH_SIZE,
+  ): Promise<RawTicket[]>[] {
+    const requests: Promise<RawTicket[]>[] = []
+    for (let i = 0; i < tickets; i = Math.min(tickets, i + batchSize)) {
+      requests.push(
+        axios
+          .get(MOVIE_TICKETS_API_URL, {
+            params: { skip: i, limit: Math.min(batchSize, tickets - i) },
+          })
+          .then(axiosResponseHandler),
+      )
+    }
+    return requests
+  }
+
+  /**
+   * Filters any invalid RawTicket entry, converts valid ones to a valid Mongo document format,
+   * persists them in batches, and returns the list of persisted Tickets.
+   *
+   * @param ticketsBatch List of promises that will be resolved to a batch of RawTicket
+   */
+  async initializeTicketsBatch(ticketsBatch: Promise<RawTicket[]>) {
+    const documents: Object[] = (await ticketsBatch)
+      // Filters any ticket with no sufficient data
+      .filter(
+        ({ title, price, inventory, date }) =>
+          title !== null && price !== null && inventory !== null && date !== null,
+      )
+      // Maps Ticket to a Mongo document, to be inserted
+      .map(({ title, genre, price, inventory, image, date }) => ({
+        title,
+        genre: transformGenres(genre),
+        price,
+        inventory,
+        imageUrl: image || "N/A",
+        date,
+      }))
+
+    // Insert in batches, so we can get better performance
+    return TicketModel.insertMany(documents)
+  }
+}
+
+export default new BonsaiDataService()

--- a/source/services/Ticket.service.ts
+++ b/source/services/Ticket.service.ts
@@ -1,0 +1,83 @@
+import { Observable } from "rxjs"
+import { Ticket } from "../entities/Ticket"
+import BonsaiDataService from "./BonsaiData.service"
+
+/**
+ * Service responsible for fetching, initializing and storing into the database,
+ * and publishing Tickets to subscribers as soon as they are ready to use.
+ */
+class TicketService {
+  initialized: boolean = false
+  ticketInitObservable: Observable<Ticket[]>
+  cachedTickets: Ticket[] = []
+
+  onValue: Function
+  onError: Function
+  onDone: Function
+
+  /**
+   * Creates (if needed) and returns the Ticket initialization observable.
+   *
+   * The observable is responsible for publishing arrays of Tickets as soon
+   * as they are fetched, initialized, and persisted into the database.
+   */
+  public getTicketsInitObservable(): Observable<Ticket[]> {
+    // If ticket is not yet initialized...
+    if (!this.ticketInitObservable) {
+      this.ticketInitObservable = Observable.create(
+        (observer: { error: Function; next: Function; complete: Function }) => {
+          // If this is the first subscriber, starts processing
+          // Tickets data
+          if (!this.initialized) {
+            this.onValue = observer.next.bind(observer)
+            this.onError = observer.error.bind(observer)
+            this.onDone = observer.complete.bind(observer)
+            this.initializeTicketProcessing()
+          }
+          // Late subscribers won't lose any data! :)
+          else {
+            console.log("Serving cached tickets...", this.cachedTickets)
+            observer.next(this.cachedTickets)
+          }
+        },
+      )
+    }
+
+    return this.ticketInitObservable
+  }
+
+  /**
+   * Tickets data pipeline.
+   * Fetch -> Initialize (validation, persistence)
+   *
+   * Once all promises are resolved, invokes "onDone".
+   */
+  private initializeTicketProcessing() {
+    // This flag is needed to avoid running this code
+    // whenever we get a new subscriber
+    this.initialized = true
+
+    Promise.all(
+      BonsaiDataService.fetchTickets().map(async batch => {
+        try {
+          const tickets = await BonsaiDataService.initializeTicketsBatch(batch)
+
+          // Caches Tickets, so next subscribers will receive this
+          // entire array at once
+          this.cachedTickets.push(...tickets)
+
+          // Publishes Tickets to subscribers
+          this.onValue(tickets)
+        } catch (err) {
+          console.error(err)
+          this.onError(err)
+        }
+      }),
+    ).then(() => {
+      console.log("Tickets initialization DONE!")
+      this.onDone()
+    })
+  }
+}
+
+export default new TicketService()

--- a/source/services/__tests__/BonsaiData.service.test.ts
+++ b/source/services/__tests__/BonsaiData.service.test.ts
@@ -1,0 +1,132 @@
+import axios from "axios"
+import BonsaiDataService from "../BonsaiData.service"
+import TicketModel from "../../entities/Ticket"
+
+const MOVIE_TICKETS_API_URL =
+  "https://us-central1-bonsai-interview-endpoints.cloudfunctions.net/movieTickets"
+
+describe("BonsaiData.service", () => {
+  describe("fetchTickets", () => {
+    afterAll(() => {
+      jest.resetAllMocks()
+    })
+
+    it("should fetch with right params", () => {
+      const getMock = jest.spyOn(axios, "get")
+
+      const promises = BonsaiDataService.fetchTickets(655, 654)
+      expect(promises).toHaveLength(2)
+
+      expect(getMock).toHaveBeenCalledTimes(2)
+      expect(getMock.mock.calls[0]).toEqual([
+        MOVIE_TICKETS_API_URL,
+        { params: { skip: 0, limit: 654 } },
+      ])
+      expect(getMock.mock.calls[1]).toEqual([
+        MOVIE_TICKETS_API_URL,
+        { params: { skip: 654, limit: 1 } },
+      ])
+    })
+  })
+
+  describe("initializeTicketsBatch", () => {
+    afterAll(() => {
+      jest.resetAllMocks()
+    })
+
+    it("should convert and persist documents", async () => {
+      const sampleData = Promise.resolve([
+        {
+          _id: {
+            $oid: "5b8701a1fc13ae6569000000",
+          },
+          title: "Long Live Death (Viva la muerte)",
+          genre: "Drama|War",
+          price: 28.704,
+          inventory: 4,
+          image: null,
+          date: "2017-09-27T05:06:56Z",
+        },
+        {
+          _id: {
+            $oid: "000000000000000000000000",
+          },
+          title: "Foo Bar",
+          genre: "Comedy|Adventure",
+          price: 99.999,
+          inventory: 9,
+          image: "http://foo.bar",
+          date: "2019-08-30T00:31:490Z",
+        },
+        {
+          _id: {
+            $oid: "000000000000000000000001",
+          },
+          title: null,
+          genre: "Comedy|Adventure",
+          price: 99.999,
+          inventory: 9,
+          image: "http://foo.bar",
+          date: "2019-08-30T00:31:490Z",
+        },
+        {
+          _id: {
+            $oid: "000000000000000000000002",
+          },
+          title: "Invalid Price",
+          genre: "Comedy|Adventure",
+          price: null,
+          inventory: 9,
+          image: "http://foo.bar",
+          date: "2019-08-30T00:31:490Z",
+        },
+        {
+          _id: {
+            $oid: "000000000000000000000003",
+          },
+          title: "Invalid Inventory",
+          genre: "Comedy|Adventure",
+          price: 99.999,
+          inventory: null,
+          image: "http://foo.bar",
+          date: "2019-08-30T00:31:490Z",
+        },
+        {
+          _id: {
+            $oid: "000000000000000000000004",
+          },
+          title: "Invalid Date",
+          genre: "Comedy|Adventure",
+          price: 99.999,
+          inventory: 9,
+          image: "http://foo.bar",
+          date: null,
+        },
+      ])
+
+      const insertManyMock = jest.spyOn(TicketModel, "insertMany").mockImplementation()
+
+      await BonsaiDataService.initializeTicketsBatch(sampleData)
+
+      expect(insertManyMock).toHaveBeenCalledTimes(1)
+      expect(insertManyMock).toHaveBeenCalledWith([
+        {
+          title: "Long Live Death (Viva la muerte)",
+          genre: ["Drama", "War"],
+          price: 28.704,
+          inventory: 4,
+          imageUrl: null,
+          date: "2017-09-27T05:06:56Z",
+        },
+        {
+          title: "Foo Bar",
+          genre: ["Comedy", "Adventure"],
+          price: 99.999,
+          inventory: 9,
+          imageUrl: "http://foo.bar",
+          date: "2019-08-30T00:31:490Z",
+        },
+      ])
+    })
+  })
+})

--- a/source/services/__tests__/BonsaiData.service.test.ts
+++ b/source/services/__tests__/BonsaiData.service.test.ts
@@ -115,7 +115,7 @@ describe("BonsaiData.service", () => {
           genre: ["Drama", "War"],
           price: 28.704,
           inventory: 4,
-          imageUrl: null,
+          imageUrl: "N/A",
           date: "2017-09-27T05:06:56Z",
         },
         {

--- a/source/services/__tests__/Ticket.service.test.ts
+++ b/source/services/__tests__/Ticket.service.test.ts
@@ -1,0 +1,73 @@
+import { Observable } from "rxjs"
+
+import BonsaiDataService from "../BonsaiData.service"
+import RawTicket from "../model/RawTicket"
+import TicketService from "../Ticket.service"
+
+describe("Ticket.service", () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it("should have correct initial state", () => {
+    expect(TicketService.initialized).toBeFalsy()
+    expect(TicketService.ticketInitObservable).toBeUndefined()
+    expect(TicketService.cachedTickets).toHaveLength(0)
+    expect(TicketService.onValue).toBeUndefined()
+    expect(TicketService.onError).toBeUndefined()
+    expect(TicketService.onDone).toBeUndefined()
+  })
+
+  it("should invoke onValue and onDone", done => {
+    const batch = Promise.resolve([
+      {
+        _id: {
+          $oid: "5b8701a2fc13ae6569000097",
+        },
+        title: null,
+        genre: null,
+        price: null,
+        inventory: null,
+        image: null,
+        date: null,
+      },
+    ])
+    const batchPromises: Promise<RawTicket[]>[] = [batch]
+    const fetchTicketsMock = jest.spyOn(BonsaiDataService, "fetchTickets").mockImplementation(
+      (): Promise<RawTicket[]>[] => {
+        return batchPromises
+      },
+    )
+    const tickets = Promise.resolve([])
+    const initializeTicketsBatchMock = jest
+      .spyOn(BonsaiDataService, "initializeTicketsBatch")
+      .mockImplementation(() => tickets)
+
+    const onValueMock = jest.fn()
+    onValueMock.bind = () => onValueMock
+
+    const onErrorMock = jest.fn()
+    const onDoneMock = jest.fn(() => {
+      expect(fetchTicketsMock).toHaveBeenCalledTimes(1)
+      expect(initializeTicketsBatchMock).toHaveBeenCalledTimes(1)
+      expect(initializeTicketsBatchMock).toHaveBeenCalledWith(batch)
+
+      expect(onValueMock).toHaveBeenCalledTimes(1)
+      expect(onErrorMock).not.toHaveBeenCalled()
+      done()
+    })
+    Observable.create = jest.fn(fn => {
+      return {
+        subscribe: () => {
+          fn({ next: onValueMock, error: onErrorMock, complete: onDoneMock })
+        },
+      }
+    })
+
+    TicketService.getTicketsInitObservable().subscribe()
+    expect(TicketService.initialized).toBeTruthy()
+    expect(TicketService.onValue).toBeDefined()
+    expect(TicketService.onError).toBeDefined()
+    expect(TicketService.onDone).toBeDefined()
+  })
+})

--- a/source/services/model/RawTicket.ts
+++ b/source/services/model/RawTicket.ts
@@ -1,0 +1,33 @@
+/**
+ * Representation of raw Ticket data, retrieved from Bonsai endpoint.
+ *
+ * Sample:
+ * {
+      "_id": {
+        "$oid": "5b8701a1fc13ae6569000000"
+      },
+      "title": "Long Live Death (Viva la muerte)",
+      "genre": "Drama|War",
+      "price": 28.704,
+      "inventory": 4,
+      "image": "http://dummyimage.com/1459x751.png/cc0000/ffffff",
+      "date": "2017-09-27T05:06:56Z"
+    }
+ */
+export default interface RawTicket {
+  _id: {
+    $oid: string
+  }
+
+  title: string | null
+
+  genre: string | null
+
+  price: number | null
+
+  inventory: number | null
+
+  image: string | null
+
+  date: string | null
+}


### PR DESCRIPTION
Provide a GraphQL endpoint to initiate cleaning and storing of ticket data into MongoDB from the provided external API.