### PR TITLE
feat(OMDbService): Try different APIs to find movie data

### DIFF
--- a/source/__tests__/services/OMDb.service.test.ts
+++ b/source/__tests__/services/OMDb.service.test.ts
@@ -90,9 +90,10 @@ describe("OMDb.service", () => {
     await OMDbService.initializeOMDbData()
 
     expect(ticketFindMock).toHaveBeenCalledTimes(1)
-    expect(fetchByTitleMock).toHaveBeenCalledTimes(2)
+    expect(fetchByTitleMock).toHaveBeenCalledTimes(3)
     expect(fetchByTitleMock.mock.calls[0][0]).toBe(ticket1.title)
     expect(fetchByTitleMock.mock.calls[1][0]).toBe(ticket2.title)
+    expect(fetchByTitleMock.mock.calls[2][0]).toBe(ticket2.title)
     expect(ticketSaveMock).toHaveBeenCalledTimes(1)
     expect(movieInsertManyMock).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
If the movie data was not found by its title, tries to find it through OMDb's "search" API, which is more generic, and may solve problems with titles ending with ", The" suffixes.
If found, then gets the movie data by its ID, which is certain to find. This is needed because "search" API does not brings all the data we need.